### PR TITLE
Rename apiKey to secret to prevent it from being published to the client

### DIFF
--- a/steam_configure.js
+++ b/steam_configure.js
@@ -4,6 +4,6 @@ Template.configureLoginServiceDialogForSteam.siteUrl = function () {
 
 Template.configureLoginServiceDialogForSteam.fields = function () {
   return [
-    {property: 'apiKey', label: 'Steam Web API Key'}
+    {property: 'secret', label: 'Steam Web API Key'}
   ];
 };

--- a/steam_server.js
+++ b/steam_server.js
@@ -47,7 +47,7 @@ var getIdentity = function (steamId) {
   try {
     response = HTTP.get("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/", {
       params: {
-      	key: config.apiKey,
+      	key: config.secret,
       	steamids: steamId
       }
     });


### PR DESCRIPTION
See
https://github.com/meteor/meteor/blob/0f98ea22fcc3f10cfd36aba66e531bf22c70f96e/packages/accounts-base/accounts_server.js#L696
